### PR TITLE
do not copy methods. thunkify => yieldly

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "thunkify": "0.0.1"
+    "yieldly": "0.0.1"
   },
   "devDependencies": {
     "memdb": "~0.1.0",


### PR DESCRIPTION
This PR does 2 things:
1. replace thunkify with yieldly (https://github.com/matthewmueller/yieldly)

Yieldly conditionally thunkifies functions depending on if a function was passed as the last argument or not. This allows us to support both generators and functions.
1. No longer copying methods and returning a new result

This breaks modules that add additional methods to leveldb, like `sublevel`.
